### PR TITLE
add -o optional options to create command

### DIFF
--- a/virtdeploy/cli.py
+++ b/virtdeploy/cli.py
@@ -40,7 +40,7 @@ EXITCODE_KEYBINT = 130
 
 def instance_create(args):
     driver = virtdeploy.get_driver(DRIVER)
-    instance = driver.instance_create(args.id, args.template)
+    instance = driver.instance_create(args.id, args.template, options=args.o)
 
     print('name: {0}'.format(instance['name']))
     print('root password: {0}'.format(instance['password']))
@@ -124,6 +124,8 @@ def parse_command_line(cmdline):
     cmd_create = cmd.add_parser('create', help='create a new instance')
     cmd_create.add_argument('id', help='new instance id')
     cmd_create.add_argument('template', help='template id')
+    cmd_create.add_argument('-o', nargs='+', required=False, metavar='OPTIONS',
+                            help='backend instance options')
 
     cmd_start = cmd.add_parser('start', help='start an instance')
     cmd_start.add_argument('--wait', action='store_true',

--- a/virtdeploy/drivers/libvirt.py
+++ b/virtdeploy/drivers/libvirt.py
@@ -78,6 +78,9 @@ class VirtDeployLibvirtDriver(VirtDeployDriverBase):
         libvirt.registerErrorHandler(libvirt_callback, ctx=None)
         return libvirt.open(self._uri)
 
+    def _options_to_dict(self, options):
+        return dict([v.split('=') for v in options or []])
+
     def template_list(self):
         templates = _get_virt_templates()
 
@@ -89,6 +92,8 @@ class VirtDeployLibvirtDriver(VirtDeployDriverBase):
 
     def instance_create(self, vmid, template, **kwargs):
         kwargs = dict(INSTANCE_DEFAULTS.items() + kwargs.items())
+        options = kwargs['options']
+        kwargs.update(self._options_to_dict(options))
 
         name = '{0}-{1}-{2}'.format(vmid, template, kwargs['arch'])
         image = '{0}.qcow2'.format(name)

--- a/virtdeploy/test_cli.py
+++ b/virtdeploy/test_cli.py
@@ -103,7 +103,7 @@ optional arguments:
         cli.parse_command_line(['create', 'test01', 'base01'])
 
         driver_mock.assert_called_with('libvirt')
-        instance_create.assert_called_with('test01', 'base01')
+        instance_create.assert_called_with('test01', 'base01', options=None)
 
     @patch('sys.stderr')
     @patch('virtdeploy.get_driver')


### PR DESCRIPTION
I needed a virt-deploy with memory and password settings. added **-o option** that get options for specific back ends ( e.g. memory and password for libvirt. )

with this PR this works:
`sudo virt-deploy create vm-test-03 centos-7.1 -o password=secret memory=2048`
